### PR TITLE
🚀 Update Slack notifier to modern file upload API

### DIFF
--- a/src/notifiers/slack.py
+++ b/src/notifiers/slack.py
@@ -48,6 +48,42 @@ class SlackNotifier(BaseNotifier):
         normalized_rms: float,
         config: Config,
     ) -> bool:
+        recording_path = self._get_recording_path(recordings, config)
+        if not recording_path:
+            return False
+
+        message = self._create_notification_message(
+            timestamp, normalized_rms, config
+        )
+
+        try:
+            filename = os.path.basename(recording_path)
+            file_size = os.path.getsize(recording_path)
+
+            upload_data = self._get_upload_url(
+                filename, file_size, message, config
+            )
+            if not upload_data:
+                return False
+
+            if not self._upload_file_to_url(
+                recording_path, upload_data["upload_url"], config
+            ):
+                return False
+
+            if not self._complete_upload(
+                upload_data["file_id"], filename, config
+            ):
+                return False
+
+            return True
+        except Exception as e:
+            config.logger.error(f"Error sending notification to Slack: {e}")
+            return False
+
+    def _get_recording_path(
+        self, recordings: List[Dict[str, Any]], config: Config
+    ) -> Optional[str]:
         recording_path = None
         for recording in recordings:
             if "path" in recording:
@@ -56,35 +92,85 @@ class SlackNotifier(BaseNotifier):
 
         if not recording_path:
             config.logger.error("No recordings available to send to Slack.")
-            return False
 
-        message = (
+        return recording_path
+
+    def _create_notification_message(
+        self, timestamp: str, normalized_rms: float, config: Config
+    ) -> str:
+        return (
             f"@channel {config.get_localized_text('noise_detected')} "
             f"{timestamp}. "
             f"{config.get_localized_text('rms_amplitude')}: "
             f"{normalized_rms:.3f}. "
         )
 
-        url = "https://slack.com/api/files.upload"
+    def _get_upload_url(
+        self, filename: str, file_size: int, message: str, config: Config
+    ) -> Optional[Dict[str, Any]]:
         headers = {"Authorization": f"Bearer {self.token}"}
-        data = {"channels": self.channel, "initial_comment": message}
+        get_url_api = "https://slack.com/api/files.getUploadURLExternal"
 
-        try:
-            with open(recording_path, "rb") as f:
-                files = {"file": f}
-                response = requests.post(
-                    url, headers=headers, data=data, files=files
-                )
+        url_params = {
+            "channels": self.channel,
+            "filename": filename,
+            "length": file_size,
+            "initial_comment": message,
+        }
 
-            result = response.json()
-            if not result.get("ok", False):
-                config.logger.error(
-                    "Error sending to Slack: "
-                    f"{result.get('error', 'Unknown error')}"
-                )
-                return False
+        url_response = requests.post(
+            get_url_api, headers=headers, data=url_params
+        )
+        url_result = url_response.json()
 
-            return True
-        except Exception as e:
-            config.logger.error(f"Error sending notification to Slack: {e}")
+        if not url_result.get("ok", False):
+            config.logger.error(
+                "Error getting upload URL from Slack: "
+                f"{url_result.get('error', 'Unknown error')}"
+            )
+            return None
+
+        return {
+            "upload_url": url_result.get("upload_url"),
+            "file_id": url_result.get("file_id"),
+        }
+
+    def _upload_file_to_url(
+        self, file_path: str, upload_url: str, config: Config
+    ) -> bool:
+        with open(file_path, "rb") as f:
+            file_content = f.read()
+            upload_response = requests.post(upload_url, data=file_content)
+
+        if upload_response.status_code != 200:
+            config.logger.error(
+                f"Error uploading file to external URL: {upload_response.status_code}"
+            )
             return False
+
+        return True
+
+    def _complete_upload(
+        self, file_id: str, filename: str, config: Config
+    ) -> bool:
+        headers = {"Authorization": f"Bearer {self.token}"}
+        complete_api = "https://slack.com/api/files.completeUploadExternal"
+
+        complete_params = {
+            "files": [{"id": file_id, "title": filename}],
+            "channel_id": self.channel,
+        }
+
+        complete_response = requests.post(
+            complete_api, headers=headers, json=complete_params
+        )
+        complete_result = complete_response.json()
+
+        if not complete_result.get("ok", False):
+            config.logger.error(
+                "Error completing file upload: "
+                f"{complete_result.get('error', 'Unknown error')}"
+            )
+            return False
+
+        return True


### PR DESCRIPTION
## 📋 Description

This PR updates the `SlackNotifier` component to use Slack's recommended method for file uploads: `files.getUploadURLExternal`. This new implementation replaces the previous `files.upload` method which is becoming deprecated.

## 🔍 Key Changes

- ♻️ Refactored the notify method by splitting it into smaller, more specific methods
- 🔄 Implemented the new three-step upload flow:
  - Get upload URL with `files.getUploadURLExternal`
  - Upload content to the provided external `URL`
  - Finalize the upload with `files.completeUploadExternal`
- 🧪 Updated test suite to verify each step of the new process
- 📝 Improved error logging for each stage of the process

## 🌟 Benefits

- ✅ Improves reliability for large file uploads
- 🔒 Follows Slack's recommended security best practices
- 🔧 More maintainable and modular code
- 📊 Better error handling and diagnostics

## 🧠 Technical Considerations

The new implementation maintains the same external interface, so no changes are required in code that uses the notifier.

## 📚 Relevant Links

[Slack documentation on files.getUploadURLExternal](https://api.slack.com/methods/files.getUploadURLExternal)
[Slack documentation on files.completeUploadExternal](https://api.slack.com/methods/files.completeUploadExternal)

---
Please pay special attention to how errors are handled at each stage of the upload process. 🙏